### PR TITLE
Use redis config from env if possible

### DIFF
--- a/.github/workflows/tests-shared.yml
+++ b/.github/workflows/tests-shared.yml
@@ -28,3 +28,6 @@ jobs:
         run: npm i
       - name: Run tests
         run: npm -w shared run test
+        env:
+          REDIS_HOST: 'host'
+          REDIS_PORT: 123

--- a/shared/package.json
+++ b/shared/package.json
@@ -9,7 +9,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "redis": "^4.6.13"
+    "@redis/client": "^1.5.14"
+  },
+  "devDependencies": {
+    "dotenv": "^16.4.5"
   },
   "repository": {
     "type": "git",

--- a/shared/src/lib/RedisClient.ts
+++ b/shared/src/lib/RedisClient.ts
@@ -1,4 +1,6 @@
-import { createClient } from 'redis';
+import { createClient } from '@redis/client';
+
+const { REDIS_HOST, REDIS_PORT } = process.env;
 
 export class RedisClient {
   private client;
@@ -6,7 +8,12 @@ export class RedisClient {
 
   constructor({ prefix }: { prefix: string }) {
     this.prefix = prefix;
-    this.client = createClient();
+    this.client = createClient({
+      socket: {
+        host: String(REDIS_HOST || 'localhost'),
+        port: Number(REDIS_PORT || 6379),
+      },
+    });
     this.client.connect();
   }
 

--- a/shared/tests/lib/RedisClient.test.ts
+++ b/shared/tests/lib/RedisClient.test.ts
@@ -10,11 +10,14 @@ const mockCreateClient = jest.fn(() => ({
   connect: mockConnect,
   quit: mockQuit,
 }));
-jest.mock('redis', () => ({
+jest.mock('@redis/client', () => ({
   createClient: mockCreateClient,
 }));
 
+import 'dotenv/config';
 import { RedisClient } from '@lib/RedisClient';
+
+const { REDIS_HOST, REDIS_PORT } = process.env;
 
 describe('Redis Client', () => {
   afterEach(() => {
@@ -26,7 +29,12 @@ describe('Redis Client', () => {
   });
   it('should create a redis client', () => {
     const client = new RedisClient({ prefix: 'test' });
-    expect(mockCreateClient).toHaveBeenCalled();
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      socket: {
+        host: String(REDIS_HOST),
+        port: Number(REDIS_PORT),
+      },
+    });
     expect(client.prefix).toEqual('test');
     expect(mockConnect).toHaveBeenCalled();
   });


### PR DESCRIPTION
Use `REDIS_HOST` and `REDIS_PORT` env variables. Defaults to `localhost:6379`